### PR TITLE
support for dns api acme mode via DNS_PROVIDER env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@ Forked from https://github.com/jwilder/nginx-proxy
 
 A new env varaible `ENABLE_ACME` is added to use acme.sh to generate free ssl cert from letsencrypt.
 
+By default, acme.sh will use Nginx mode to obtain a certificate. DNS APIs can also be used, triggered by setting a DNS_PROVIDER environment variable.
+
 All the other options are the same as the upstream project: https://github.com/jwilder/nginx-proxy
 
-It's very easy to use:
+It's very easy to use.
 
 ### 1. Run nginx reverse proxy
+
+#### Nginx mode
 
 ```sh
 docker run  \
@@ -35,10 +39,35 @@ docker run  \
 neilpang/nginx-proxy
 ```
 
-For a docker compose v2 or v3 project, every project has a dedicated network, so, you must use `--net=host` option,  so that it can proxy any projects on you machine.
+#### Automatic DNS API integration
+
+Set DNS_PROVIDER to the provider the same value as the --dns option in acme.sh. Add the environment variables required by the specific provider.
+
+Example with Cloudflare:
+
+```sh
+docker run  \
+-p 80:80 \
+-p 443:443 \
+-it  -d --rm  \
+-e DNS_PROVIDER=dns_cf \
+-e CF_Key="<cloudflare key>" \
+-e CF_Email="<cloudflare email>" \
+-v /var/run/docker.sock:/tmp/docker.sock:ro  \
+-v $(pwd)/proxy/certs:/etc/nginx/certs \
+-v $(pwd)/proxy/acme:/acmecerts \
+-v $(pwd)/proxy/conf.d:/etc/nginx/conf.d \
+--name proxy \
+neilpang/nginx-proxy
+```
+
+For all other providers, see https://github.com/Neilpang/acme.sh/tree/master/dnsapi.
 
 
 #### Docker Compose
+
+For a docker compose v2 or v3 project, every project has a dedicated network, so, you must use `--net=host` option,  so that it can proxy any projects on you machine.
+
 ```yaml
 version: '2'
 

--- a/updatessl.sh
+++ b/updatessl.sh
@@ -11,6 +11,12 @@ CERTS="/etc/nginx/certs"
 
 
 updatessl() {
+  if [ -n "$DNS_PROVIDER" ]; then
+    PROVIDER_OPT="--dns $DNS_PROVIDER"
+  else
+    PROVIDER_OPT=--nginx
+  fi
+
   nginx -t && nginx -s reload
   if grep ACME_DOMAINS $DEFAULT_CONF ; then
     for d_list in $(grep ACME_DOMAINS $DEFAULT_CONF | cut -d ' ' -f 2);
@@ -18,7 +24,7 @@ updatessl() {
       d=$(echo "$d_list" | cut -d , -f 1)
       $ACME_BIN --issue \
       -d $d_list \
-      --nginx \
+      $PROVIDER_OPT \
       --fullchain-file "$CERTS/$d.crt" \
       --key-file "$CERTS/$d.key" \
       --reloadcmd "nginx -t && nginx -s reload"
@@ -32,9 +38,4 @@ updatessl() {
   nginx -t && nginx -s reload
 }
 
-
-
 "$@"
-
-
-


### PR DESCRIPTION
I added the ability to use the DNS API acme method for obtaining a letsencrypt certificate by setting a DNS_PROVIDER environment variable, e.g. DNS_PROVIDER=dns_cf.

Updated README.md as well.
